### PR TITLE
Missing Key Exception

### DIFF
--- a/Index.py
+++ b/Index.py
@@ -3,6 +3,7 @@ import json
 from functools import reduce
 from operator import getitem
 from pathlib import Path
+from itertools import chain
 
 class Index:
     def __init__(self, key_names, rootPath, filename=None):
@@ -44,7 +45,10 @@ class Index:
             key_names = list(self.unique_indices)
             for key_name in key_names:
                 # get the value in the file that we will index on
-                key = reduce(getitem, key_name, f)
+                try:
+                    key = reduce(getitem, key_name, f)
+                except KeyError:
+                    key = None
 
                 # if we don't already have a filename for this key, add this filename 
                 if not self.unique_indices.get(key_name).get(key, False):
@@ -58,7 +62,10 @@ class Index:
             # check each of the group_indices key names
             for key_name in self.group_indices:
                 # get the value in the file that we will index on
-                key = reduce(getitem, key_name, f)
+                try:
+                    key = reduce(getitem, key_name, f)
+                except KeyError:
+                    key = None
 
                 # if we have already added the key to the group_keys[keyname], just
                 # add our filename to the set for that key. otherwise, we must add

--- a/test_JsonPydexer.py
+++ b/test_JsonPydexer.py
@@ -161,7 +161,6 @@ class PydexerIndex(unittest.TestCase):
         jp.index(["_id"])
         with open(".jp.pkl", "rb") as f:
             index = pickle.load(f)
-            os.remove(".jp.pkl")
             expectedDict = {
                 "5a0a0239b4b70140c8827119": "1.json",
                 None: "2.json",
@@ -170,6 +169,20 @@ class PydexerIndex(unittest.TestCase):
                 "5a0a02399416569dc1f3fedd": "5.json"
             }
             self.assertEqual(index.unique_indices[('_id',)], expectedDict)
+        # test again with nested and nonunique key 
+        jp.index(["foo", "guid"])
+        with open(".jp.pkl", "rb") as f:
+            index = pickle.load(f)
+            os.remove(".jp.pkl")
+            expectedDict = {
+                ("foo", "guid"): {
+                    "9d634636-c7a3-48d1-9ec7-5fc91e50aaf4": "1.json",
+                    "fa75756f-8fbd-4848-9d2f-5ee9df0f149f": "3.json",
+                    "c11c222d-0f07-4984-b240-a0a4e22ddcf8": "5.json",
+                    None: {"2.json", "4.json"}
+                }
+            }
+            self.assertEqual(index.group_indices[("foo", "guid")], expectedDict)
 
 
 if __name__ == '__main__':

--- a/test_JsonPydexer.py
+++ b/test_JsonPydexer.py
@@ -161,6 +161,7 @@ class PydexerIndex(unittest.TestCase):
         jp.index(["_id"])
         with open(".jp.pkl", "rb") as f:
             index = pickle.load(f)
+            os.remove(".jp.pkl")
             expectedDict = {
                 "5a0a0239b4b70140c8827119": "1.json",
                 None: "2.json",
@@ -169,20 +170,24 @@ class PydexerIndex(unittest.TestCase):
                 "5a0a02399416569dc1f3fedd": "5.json"
             }
             self.assertEqual(index.unique_indices[('_id',)], expectedDict)
-        # test again with nested and nonunique key 
-        jp.index(["foo", "guid"])
+
+
+    def test_index_missing_nested_keys(self):
+        # test with nested and nonunique key
+        jp = JsonPydexer(self.missing_keys_dir)
+        jp.index([["foo", "guid"]])
         with open(".jp.pkl", "rb") as f:
             index = pickle.load(f)
             os.remove(".jp.pkl")
             expectedDict = {
                 ("foo", "guid"): {
-                    "9d634636-c7a3-48d1-9ec7-5fc91e50aaf4": "1.json",
-                    "fa75756f-8fbd-4848-9d2f-5ee9df0f149f": "3.json",
-                    "c11c222d-0f07-4984-b240-a0a4e22ddcf8": "5.json",
+                    "9d634636-c7a3-48d1-9ec7-5fc91e50aaf4": { "1.json" },
+                    "fa75756f-8fbd-4848-9d2f-5ee9df0f149f": { "3.json" },
+                    "c11c222d-0f07-4984-b240-a0a4e22ddcf8": { "5.json" },
                     None: {"2.json", "4.json"}
                 }
             }
-            self.assertEqual(index.group_indices[("foo", "guid")], expectedDict)
+            self.assertEqual(index.group_indices, expectedDict)
 
 
 if __name__ == '__main__':

--- a/test_JsonPydexer.py
+++ b/test_JsonPydexer.py
@@ -36,6 +36,7 @@ class PydexerIndex(unittest.TestCase):
     good_dir = "test_data/1"
     recursive_dir = "test_data/2"
     groups_dir = "test_data/3"
+    missing_keys_dir = "test_data/4"
 
     def test_index(self):
         jp = JsonPydexer(self.good_dir)
@@ -154,6 +155,21 @@ class PydexerIndex(unittest.TestCase):
             self.assertEqual(index.unique_indices, expectedDict)
             os.remove(".jp.pkl")
 
+
+    def test_index_missing_keys(self):
+        jp = JsonPydexer(self.missing_keys_dir)
+        jp.index(["_id"])
+        with open(".jp.pkl", "rb") as f:
+            index = pickle.load(f)
+            os.remove(".jp.pkl")
+            expectedDict = {
+                "5a0a0239b4b70140c8827119": "1.json",
+                None: "2.json",
+                "5a0a0239ef483b81585699c5": "3.json",
+                "5a0a0239a78b6240acaebdb5": "4.json",
+                "5a0a02399416569dc1f3fedd": "5.json"
+            }
+            self.assertEqual(index.unique_indices[('_id',)], expectedDict)
 
 
 if __name__ == '__main__':

--- a/test_data/4/1.json
+++ b/test_data/4/1.json
@@ -1,0 +1,8 @@
+{
+    "_id": "5a0a0239b4b70140c8827119",
+    "index": 0,
+    "foo": {
+        "guid": "9d634636-c7a3-48d1-9ec7-5fc91e50aaf4"
+    },
+    "name": "Lorene Miranda"
+}

--- a/test_data/4/2.json
+++ b/test_data/4/2.json
@@ -1,0 +1,8 @@
+
+{
+    "index": 1,
+    "foo": {
+    },
+    "name": "Burnett Morrow"
+}
+

--- a/test_data/4/3.json
+++ b/test_data/4/3.json
@@ -1,0 +1,8 @@
+{
+    "_id": "5a0a0239ef483b81585699c5",
+    "index": 2,
+    "foo": {
+        "guid": "fa75756f-8fbd-4848-9d2f-5ee9df0f149f"
+    },
+    "name": "Mitchell Richardson"
+}

--- a/test_data/4/4.json
+++ b/test_data/4/4.json
@@ -1,0 +1,8 @@
+{
+    "_id": "5a0a0239a78b6240acaebdb5",
+    "index": 3,
+    "foo": {
+        "guid": "a1b422cb-e54b-4359-aa4f-3b486ce858a0"
+    },
+    "name": "Bishop Marks"
+}

--- a/test_data/4/4.json
+++ b/test_data/4/4.json
@@ -2,7 +2,6 @@
     "_id": "5a0a0239a78b6240acaebdb5",
     "index": 3,
     "foo": {
-        "guid": "a1b422cb-e54b-4359-aa4f-3b486ce858a0"
     },
     "name": "Bishop Marks"
 }

--- a/test_data/4/5.json
+++ b/test_data/4/5.json
@@ -1,0 +1,8 @@
+ {
+    "_id": "5a0a02399416569dc1f3fedd",
+    "index": 4,
+    "foo": {
+        "guid": "c11c222d-0f07-4984-b240-a0a4e22ddcf8"
+    },
+    "name": "Kirk Harrington"
+}


### PR DESCRIPTION
In the process of this, I discovered that somewhere in the process of converting to group_indices, nested indices are split into non-nested indicies, ie ("foo", "bar") is split into ("foo"), ("bar")